### PR TITLE
Add headset settings menu backed by Jabra_GetSetting/SetSettings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ jLink brings the power of Jabra device management to your Linux system.
 
 
 
+## Build from source
+
+The Jabra SDK shared library is not committed to git (`lib/` is local only). Before building:
+
+```bash
+./setup-lib.sh          # creates lib/libjabra.so (or copies from /usr/lib/jabra if you ran install.sh)
+go build -o jLink .
+./jLink
+```
+
+Requires: Go 1.23+, gcc, ALSA and libcurl **development** packages.
+
+- **Fedora:** `sudo dnf install golang gcc alsa-lib-devel libcurl-devel`
+- **Debian/Ubuntu:** `sudo apt install golang gcc libasound2-dev libcurl4-openssl-dev`
+
+Then:
+
+```bash
+./setup-lib.sh
+go build -o jLink .
+```
+
+On Fedora, `setup-lib.sh` also downloads a compatible `libcurl.so.4` (Ubuntu build with `CURL_OPENSSL_4`) because Fedora’s system libcurl does not match the embedded Jabra SDK. Requires `curl`, `zstd`, and `ar` (binutils).
+
+Alternatively use the prebuilt binary: `curl -so- https://raw.githubusercontent.com/Watchdog0x/jLink/main/install.sh | sudo bash`
+
 ## Installation and update
 <div align="center">
   <img src="./src/install.png" alt="How jLink look" style="max-width: 100%; height: auto;">
@@ -75,7 +101,7 @@ wget -qO- https://raw.githubusercontent.com/Watchdog0x/jLink/main/install.sh | s
 
     1. Code Cleanup: Improve the current codebase, which is in need of refactoring.
     2.  Device Switching: Add support for switching between multiple connected devices.
-    3. Headset Settings: Implement features for configuring advanced headset settings.
+    3. ~~Headset Settings: Implement features for configuring advanced headset settings.~~ ✓ Done
     4. Sound Control: Integrate with PipeWire for precise sound management.
     5. Daemon Service: Create a background service using IPC shared memory for seamless operation
 

--- a/cmd.go
+++ b/cmd.go
@@ -45,6 +45,20 @@ var (
 
 	selectedItemsSearchForNewDevices = -1
 	menuItemsSearchForNewDevices     = [2]string{"Q Back", "1 Connect"}
+
+	// Headset Settings state
+	//
+	// hsDisplay is the flat, scrollable list shown on screen. It is built
+	// from deviceSettings.items once per visit and reset to nil on exit so
+	// that re-entering always shows the freshest data.
+	hsDisplay    []hsDisplayItem
+	hsCurSel     int // cursor row in hsDisplay (skips header rows)
+	hsSaveFlash  int // countdown frames to show "Saved!" banner
+	hsErrStr     string
+	// hsEditIdx >= 0 means we are in the value-picker sub-view for that
+	// hsDisplay row; hsEditOptSel is the highlighted option inside it.
+	hsEditIdx    int = -1
+	hsEditOptSel int
 )
 
 const (
@@ -53,6 +67,14 @@ const (
 	batteryWidth        = 10
 	lowBatteryThreshold = 20
 )
+
+// hsDisplayItem is one row in the headset-settings screen.
+// Group-name headers (isHeader == true) are rendered but not selectable.
+type hsDisplayItem struct {
+	isHeader bool
+	header   string // group name when isHeader
+	settIdx  int    // index into deviceSettings.items when !isHeader
+}
 
 func enableRawMode() (*unix.Termios, error) {
 
@@ -192,11 +214,71 @@ func startKeysPressedListener() {
 			case 'q': // Back To Start Menu
 				startMenuSelected = -1
 			}
+		// ############# Headset Settings ##################
+		case 5:
+			if hsEditIdx >= 0 && hsDisplay != nil && hsEditIdx < len(hsDisplay) {
+				// ---- value-picker sub-view ----
+				item := hsDisplay[hsEditIdx]
+				headset, hExists := deviceManager[selectedHeadset]
+				if !hExists || headset.deviceSettings == nil {
+					hsEditIdx = -1
+					break
+				}
+				s := headset.deviceSettings.items[item.settIdx]
+				switch key {
+				case 'w':
+					if hsEditOptSel > 0 {
+						hsEditOptSel--
+					}
+				case 's':
+					if hsEditOptSel < len(s.listKeyValue)-1 {
+						hsEditOptSel++
+					}
+				case '\r':
+					chosen := s.listKeyValue[hsEditOptSel].key
+					if writeErr := applySettingByte(headset.deviceID, &headset.deviceSettings, s.guid, uint8(chosen)); writeErr != nil {
+						hsErrStr = writeErr.Error()
+					} else {
+						hsErrStr = ""
+						hsSaveFlash = 24
+					}
+					hsDisplay = nil // rebuild display from fresh data next frame
+					hsEditIdx = -1
+				case 'q':
+					hsEditIdx = -1
+				}
+			} else {
+				// ---- main settings list ----
+				switch key {
+				case 'q':
+					hsDisplay = nil
+					hsCurSel = 0
+					hsErrStr = ""
+					hsEditIdx = -1
+					startMenuSelected = -1
+				case 'w':
+					hsMoveUp()
+				case 's':
+					hsMoveDown()
+				case '\r':
+					hsActivate()
+				}
+			}
 		}
 	}
 }
 
 func handleUpKey() {
+	if menuState == 5 {
+		if hsEditIdx >= 0 {
+			if hsEditOptSel > 0 {
+				hsEditOptSel--
+			}
+		} else {
+			hsMoveUp()
+		}
+		return
+	}
 	if currentSelection > 0 {
 		currentSelection--
 	}
@@ -217,6 +299,17 @@ func handleDownKey() {
 	case 3: // Dongle Settings
 		if currentSelection < len(dongleSettignsMenu)-1 {
 			currentSelection++
+		}
+	case 5: // Headset Settings
+		if hsEditIdx >= 0 && hsDisplay != nil && hsEditIdx < len(hsDisplay) {
+			if headset, ok := deviceManager[selectedHeadset]; ok && headset.deviceSettings != nil {
+				s := headset.deviceSettings.items[hsDisplay[hsEditIdx].settIdx]
+				if hsEditOptSel < len(s.listKeyValue)-1 {
+					hsEditOptSel++
+				}
+			}
+		} else {
+			hsMoveDown()
 		}
 	}
 }
@@ -485,7 +578,8 @@ func startUi() {
 					fmt.Println("Switch Device")
 					menuState = 4
 				case 4: // HeadSet Settings
-					fmt.Println("HeadSet Settings")
+					menuState = 5
+					headsetSettingsScreen()
 				case 5: // Exit
 					return
 				}
@@ -497,4 +591,253 @@ func startUi() {
 			time.Sleep(time.Second / 12) // 12 Fps
 		}
 	}
+}
+
+// hsBuildDisplay constructs (or rebuilds) hsDisplay from the headset's
+// cached deviceSettings. Items are grouped by groupName; group-name headers
+// are interleaved as non-selectable rows. Non-interactive types (labels,
+// rulers, plain buttons) are omitted entirely.
+func hsBuildDisplay() {
+	hsDisplay = nil
+	headset, ok := deviceManager[selectedHeadset]
+	if !ok || headset.deviceSettings == nil {
+		return
+	}
+
+	var lastGroup string
+	for i, s := range headset.deviceSettings.items {
+		switch s.cntrlType {
+		case cntrlLabel, cntrlHorzRuler, cntrlButton, cntrlEditButton:
+			continue
+		}
+		if s.groupName != "" && s.groupName != lastGroup {
+			hsDisplay = append(hsDisplay, hsDisplayItem{isHeader: true, header: s.groupName})
+			lastGroup = s.groupName
+		}
+		hsDisplay = append(hsDisplay, hsDisplayItem{settIdx: i})
+	}
+}
+
+// hsMoveUp moves the cursor up, skipping group-header rows.
+func hsMoveUp() {
+	for pos := hsCurSel - 1; pos >= 0; pos-- {
+		if !hsDisplay[pos].isHeader {
+			hsCurSel = pos
+			return
+		}
+	}
+}
+
+// hsMoveDown moves the cursor down, skipping group-header rows.
+func hsMoveDown() {
+	for pos := hsCurSel + 1; pos < len(hsDisplay); pos++ {
+		if !hsDisplay[pos].isHeader {
+			hsCurSel = pos
+			return
+		}
+	}
+}
+
+// hsActivate handles Enter on the currently highlighted setting.
+func hsActivate() {
+	if hsCurSel < 0 || hsCurSel >= len(hsDisplay) {
+		return
+	}
+	item := hsDisplay[hsCurSel]
+	if item.isHeader {
+		return
+	}
+
+	headset, ok := deviceManager[selectedHeadset]
+	if !ok || headset.deviceSettings == nil {
+		return
+	}
+	s := headset.deviceSettings.items[item.settIdx]
+
+	if s.isProtected && s.isProtectionEnabled {
+		return // greyed out — skip silently
+	}
+
+	switch s.cntrlType {
+	case cntrlToggle:
+		// Pick the "other" valid key. Some Jabra toggles don't use {0, 1};
+		// the device-side keys come from the manifest (e.g. {0, 2}).
+		var newVal uint8
+		if len(s.listKeyValue) >= 2 {
+			found := false
+			for _, o := range s.listKeyValue {
+				if uint16(s.currByte) != o.key {
+					newVal = uint8(o.key)
+					found = true
+					break
+				}
+			}
+			if !found {
+				newVal = uint8(s.listKeyValue[0].key)
+			}
+		} else {
+			newVal = 1
+			if s.currByte != 0 {
+				newVal = 0
+			}
+		}
+		if writeErr := applySettingByte(headset.deviceID, &headset.deviceSettings, s.guid, newVal); writeErr != nil {
+			hsErrStr = writeErr.Error()
+		} else {
+			hsErrStr = ""
+			hsSaveFlash = 24
+		}
+		hsDisplay = nil // rebuild on next frame
+
+	case cntrlRadio, cntrlDrpDown, cntrlComboBox:
+		if len(s.listKeyValue) == 0 {
+			return
+		}
+		hsEditIdx = hsCurSel
+		hsEditOptSel = 0
+		for i, o := range s.listKeyValue {
+			if o.key == uint16(s.currByte) {
+				hsEditOptSel = i
+				break
+			}
+		}
+	}
+}
+
+// headsetSettingsScreen is the top-level render call for menuState == 5.
+func headsetSettingsScreen() {
+	// Build the display list on first visit or after a write.
+	if hsDisplay == nil {
+		hsBuildDisplay()
+		// Move cursor to first selectable row.
+		hsCurSel = 0
+		for hsCurSel < len(hsDisplay) && hsDisplay[hsCurSel].isHeader {
+			hsCurSel++
+		}
+		hsEditIdx = -1
+	}
+
+	drawingBox()
+
+	headset, hExists := deviceManager[selectedHeadset]
+	if !hExists || headset.deviceSettings == nil {
+		moveCursor(5, 8)
+		fmt.Print("\033[31mNo headset connected or settings unavailable.\033[0m")
+		moveCursor(height-3, 7)
+		fmt.Print("\033[42m Q Back \033[0m")
+		return
+	}
+
+	if hsErrStr != "" {
+		moveCursor(height-5, 8)
+		maxW := width - 16
+		msg := hsErrStr
+		if maxW > 0 && len(msg) > maxW {
+			msg = msg[:maxW] + "…"
+		}
+		fmt.Printf("\033[31mError: %s\033[0m", msg)
+	}
+	if hsSaveFlash > 0 {
+		hsSaveFlash--
+		moveCursor(height-5, 8)
+		fmt.Print("\033[42m Saved! \033[0m")
+	}
+
+	if hsEditIdx >= 0 && hsEditIdx < len(hsDisplay) {
+		// ---- value-picker sub-view ----
+		editItem := hsDisplay[hsEditIdx]
+		s := headset.deviceSettings.items[editItem.settIdx]
+
+		moveCursor(4, 8)
+		fmt.Printf("Setting: \033[1m%s\033[0m", s.name)
+		if s.helpText != "" && s.helpText != s.name {
+			moveCursor(5, 8)
+			help := s.helpText
+			maxW := width - 16
+			if maxW > 0 && len(help) > maxW {
+				help = help[:maxW] + "…"
+			}
+			fmt.Printf("\033[2m%s\033[0m", help)
+		}
+
+		for i, opt := range s.listKeyValue {
+			moveCursor(7+i, 10)
+			marker := "  "
+			if opt.key == uint16(s.currByte) {
+				marker = "✓ "
+			}
+			line := fmt.Sprintf("%s%s", marker, opt.value)
+			if i == hsEditOptSel {
+				fmt.Printf("\033[42m %s \033[0m", line)
+			} else {
+				fmt.Printf(" %s ", line)
+			}
+		}
+
+		moveCursor(height-3, 7)
+		fmt.Print("\033[42m Q Back \033[0m  \033[42m Enter Select \033[0m")
+		return
+	}
+
+	// ---- main settings list ----
+	innerRows := height - 7
+	if innerRows < 1 {
+		innerRows = 1
+	}
+
+	scrollOffset := 0
+	if hsCurSel >= innerRows {
+		scrollOffset = hsCurSel - innerRows + 1
+	}
+
+	nameMax := width - 32
+	if nameMax < 10 {
+		nameMax = 10
+	}
+
+	for i, item := range hsDisplay {
+		visRow := i - scrollOffset
+		if visRow < 0 || visRow >= innerRows {
+			continue
+		}
+		moveCursor(4+visRow, 8)
+
+		if item.isHeader {
+			// Group header: bold, dimmed, not selectable.
+			grp := item.header
+			if len(grp) > nameMax+20 {
+				grp = grp[:nameMax+19] + "…"
+			}
+			fmt.Printf(" \033[1;2m── %s ──\033[0m", grp)
+			continue
+		}
+
+		s := headset.deviceSettings.items[item.settIdx]
+		name := s.name
+		if len(name) > nameMax {
+			name = name[:nameMax-1] + "…"
+		}
+
+		suffix := ""
+		if s.isDeviceRestart {
+			suffix += " (reboot required)"
+		}
+		valLabel := settingValueLabel(s)
+
+		var line string
+		if s.isProtected && s.isProtectionEnabled {
+			line = fmt.Sprintf("\033[2m%-*s  %s 🔒%s\033[0m", nameMax, name, valLabel, suffix)
+		} else {
+			line = fmt.Sprintf("%-*s  %s%s", nameMax, name, valLabel, suffix)
+		}
+
+		if i == hsCurSel {
+			fmt.Printf("\033[42m %s \033[0m", line)
+		} else {
+			fmt.Printf(" %s ", line)
+		}
+	}
+
+	moveCursor(height-3, 7)
+	fmt.Print("\033[42m Q Back \033[0m  \033[42m Enter Edit \033[0m  \033[42m W/S Navigate \033[0m")
 }

--- a/headsetSettings.go
+++ b/headsetSettings.go
@@ -1,0 +1,205 @@
+package main
+
+/*
+#cgo CFLAGS: -Iheaders
+
+#include "Common.h"
+#include "JabraDeviceConfig.h"
+#include <stdlib.h>
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// controlType mirrors the C ControlType enum from JabraDeviceConfig.h.
+type controlType int
+
+const (
+	cntrlRadio      controlType = iota // 0
+	cntrlToggle                        // 1
+	cntrlComboBox                      // 2
+	cntrlDrpDown                       // 3
+	cntrlLabel                         // 4
+	cntrlTextBox                       // 5
+	cntrlButton                        // 6
+	cntrlEditButton                    // 7
+	cntrlHorzRuler                     // 8
+	cntrlPwdTextBox                    // 9
+	cntrlUnknown                       // 10
+)
+
+// listKeyValue is the Go mirror of C.ListKeyValue (key → display label).
+type listKeyValue struct {
+	key   uint16
+	value string
+}
+
+// settingInfo is the Go mirror of one C.SettingInfo entry.
+type settingInfo struct {
+	guid, name, helpText, groupName string
+	cntrlType                       controlType
+	dataType                        int // 0 = byte, 1 = string
+	currByte                        uint8
+	currString                      string
+	listKeyValue                    []listKeyValue
+	isDeviceRestart                 bool
+	isProtected                     bool
+	isProtectionEnabled             bool
+}
+
+// deviceSettings holds the parsed settings list and the live C pointer.
+// raw is kept alive so we can mutate currValue in-place and call Jabra_SetSettings.
+type deviceSettings struct {
+	items []settingInfo
+	raw   *C.DeviceSettings
+}
+
+// getDeviceSettings fetches all settings for deviceID from the Jabra SDK.
+//
+// The SDK downloads a device-model manifest from Jabra's servers and overlays
+// the current EEPROM values. Every setting exposed in Jabra Direct (sidetone
+// level, mute reminder, auto-accept on boom-arm, on-head auto-pause, …) is
+// returned here, identified by a device-specific GUID.
+//
+// The caller MUST eventually call freeDeviceSettings to release C memory.
+func getDeviceSettings(deviceID uint16) (*deviceSettings, error) {
+	cSettings := C.Jabra_GetSettings(C.ushort(deviceID))
+	if cSettings == nil {
+		return nil, fmt.Errorf("Jabra_GetSettings returned nil (device %d)", deviceID)
+	}
+
+	if err := checkErrorStatus(errorStatusCode(cSettings.errStatus)); err != nil {
+		C.Jabra_FreeDeviceSettings(cSettings)
+		return nil, err
+	}
+
+	count := int(cSettings.settingCount)
+	ds := &deviceSettings{
+		items: make([]settingInfo, 0, count),
+		raw:   cSettings,
+	}
+	if count == 0 {
+		return ds, nil
+	}
+
+	cInfos := (*[1 << 14]C.SettingInfo)(unsafe.Pointer(cSettings.settingInfo))[:count:count]
+	for _, ci := range cInfos {
+		s := settingInfo{
+			guid:                C.GoString(ci.guid),
+			name:                C.GoString(ci.name),
+			helpText:            C.GoString(ci.helpText),
+			groupName:           C.GoString(ci.groupName),
+			cntrlType:           controlType(ci.cntrlType),
+			dataType:            int(ci.settingDataType),
+			isDeviceRestart:     bool(ci.isDeviceRestart),
+			isProtected:         bool(ci.isSettingProtected),
+			isProtectionEnabled: bool(ci.isSettingProtectionEnabled),
+		}
+
+		if ci.currValue != nil {
+			if s.dataType == 0 {
+				s.currByte = uint8(*(*C.uint8_t)(ci.currValue))
+			} else {
+				s.currString = C.GoString((*C.char)(ci.currValue))
+			}
+		}
+
+		if ci.listSize > 0 && ci.listKeyValue != nil {
+			n := int(ci.listSize)
+			opts := (*[1 << 16]C.ListKeyValue)(unsafe.Pointer(ci.listKeyValue))[:n:n]
+			for _, o := range opts {
+				s.listKeyValue = append(s.listKeyValue, listKeyValue{
+					key:   uint16(o.key),
+					value: C.GoString(o.value),
+				})
+			}
+		}
+
+		ds.items = append(ds.items, s)
+	}
+	return ds, nil
+}
+
+// freeDeviceSettings releases the C memory owned by ds.
+func freeDeviceSettings(ds *deviceSettings) {
+	if ds != nil && ds.raw != nil {
+		C.Jabra_FreeDeviceSettings(ds.raw)
+		ds.raw = nil
+	}
+}
+
+// applySettingByte writes a single byte-valued setting (identified by GUID)
+// to the headset's EEPROM.
+//
+// We use the single-setting form Jabra_GetSetting(guid) instead of writing the
+// full settings blob back. The blob form (Jabra_SetSettings on the whole list)
+// fails with ParameterFail (4) if *any* other setting in the blob is invalid
+// or write-protected — which is common on real devices.
+//
+// After the write, *ds is refreshed by freeing + reloading the full settings
+// list so that the displayed value reflects what the device actually accepted.
+func applySettingByte(deviceID uint16, ds **deviceSettings, guid string, newByte uint8) error {
+	cGuid := C.CString(guid)
+	defer C.free(unsafe.Pointer(cGuid))
+
+	one := C.Jabra_GetSetting(C.ushort(deviceID), cGuid)
+	if one == nil {
+		return fmt.Errorf("Jabra_GetSetting(%q) returned nil", guid)
+	}
+	defer C.Jabra_FreeDeviceSettings(one)
+
+	if err := checkErrorStatus(errorStatusCode(one.errStatus)); err != nil {
+		return err
+	}
+	if one.settingCount == 0 || one.settingInfo == nil {
+		return fmt.Errorf("setting %q not found on device", guid)
+	}
+
+	// one.settingInfo points at exactly one SettingInfo.
+	info := (*C.SettingInfo)(unsafe.Pointer(one.settingInfo))
+	if info.currValue == nil {
+		return fmt.Errorf("setting %q has no writable value slot", guid)
+	}
+	if info.settingDataType != 0 {
+		return fmt.Errorf("setting %q is not a byte setting", guid)
+	}
+
+	*(*C.uint8_t)(info.currValue) = C.uint8_t(newByte)
+
+	rc := returnCode(int(C.Jabra_SetSettings(C.ushort(deviceID), one)))
+
+	// Reload the full settings blob so the UI reflects the device state.
+	freeDeviceSettings(*ds)
+	fresh, loadErr := getDeviceSettings(deviceID)
+	*ds = fresh
+
+	if rc != nil {
+		return rc
+	}
+	return loadErr
+}
+
+// settingValueLabel returns a short human-readable string for the current
+// value of a setting (the matching option label, or "ON"/"OFF" for toggles).
+func settingValueLabel(s settingInfo) string {
+	if len(s.listKeyValue) > 0 {
+		for _, o := range s.listKeyValue {
+			if o.key == uint16(s.currByte) {
+				return o.value
+			}
+		}
+		return fmt.Sprintf("(%d)", s.currByte)
+	}
+	if s.cntrlType == cntrlToggle {
+		if s.currByte != 0 {
+			return "ON"
+		}
+		return "OFF"
+	}
+	if s.dataType == 1 {
+		return s.currString
+	}
+	return fmt.Sprintf("%d", s.currByte)
+}

--- a/jabraApi.go
+++ b/jabraApi.go
@@ -2,7 +2,6 @@ package main
 
 /*
 #cgo CFLAGS: -Iheaders
-#cgo LDFLAGS: -Llib -ljabra
 
 #include "Common.h"
 #include "JabraDeviceConfig.h"
@@ -36,6 +35,7 @@ type jabra_DeviceInfo struct {
 	featureFlags           *featureFlags
 	batteryStatus          *batteryStatus
 	pairingList            *pairingList
+	deviceSettings         *deviceSettings
 }
 
 type batteryComponent int
@@ -262,6 +262,13 @@ func deviceAttachedFunc(deviceInfo C.Jabra_DeviceInfo) {
 		} else {
 			goDeviceInfo.batteryStatus = battery
 		}
+
+		ds, err := getDeviceSettings(goDeviceInfo.deviceID)
+		if err != nil {
+			fmt.Printf("Get Device Settings for %s: %s\n", goDeviceInfo.deviceName, err)
+		} else {
+			goDeviceInfo.deviceSettings = ds
+		}
 	} else {
 		if goDeviceInfo.featureFlags.pairingList {
 			goDeviceInfo.pairingList = getPairingList(goDeviceInfo.deviceID)
@@ -409,9 +416,9 @@ func updateStartMenu() {
 	// 	startMenu = append(startMenu, menuItem{id: 3, label: "Switch Device"})
 	// }
 
-	// if device, deviceexists := deviceManager[selectedHeadset]; deviceexists {
-	// 	startMenu = append(startMenu, menuItem{id: 4, label: fmt.Sprintf("%s Settings", device.deviceName)})
-	// }
+	if headset, ok := deviceManager[selectedHeadset]; ok && headset.deviceSettings != nil {
+		startMenu = append(startMenu, menuItem{id: 4, label: fmt.Sprintf("%s Settings", headset.deviceName)})
+	}
 
 	startMenu = append(startMenu, menuItem{id: 5, label: "Exit"})
 
@@ -489,6 +496,16 @@ func (d *devices) add(deviceInfo *jabra_DeviceInfo) {
 func (d *devices) removed(deviceID uint16) {
 	if *d == nil {
 		return
+	}
+
+	// Free C memory for the device being removed.
+	for i := 0; i < len(*d); i++ {
+		device, exists := (*d)[i]
+		if exists && device.deviceID == deviceID {
+			freeDeviceSettings(device.deviceSettings)
+			device.deviceSettings = nil
+			break
+		}
 	}
 
 	var (

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 /*
 #cgo CFLAGS: -Iheaders
-#cgo LDFLAGS: -Llib -ljabra
+#cgo LDFLAGS: -L${SRCDIR}/lib -Wl,-rpath,${SRCDIR}/lib -ljabra -l:libcurl.so.4
 
 #include "Common.h"
 #include "GoWrapper.h"

--- a/setup-lib.sh
+++ b/setup-lib.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Populate lib/ for local builds (not committed to git).
+#  - libjabra.so   from install.sh embedded blob or /usr/lib/jabra
+#  - libcurl.so.4  system copy or Ubuntu package when CURL_OPENSSL_4 is missing (Fedora)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+mkdir -p lib
+
+UBUNTU_LIBCURL_DEB="http://archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4t64_8.5.0-2ubuntu10_amd64.deb"
+JABRA_MD5="5092ca68e1b6081de35ccd001f2d974f"
+
+system_libcurl_paths() {
+	# Common locations on Linux amd64
+	printf '%s\n' \
+		/usr/lib/x86_64-linux-gnu/libcurl.so.4 \
+		/usr/lib64/libcurl.so.4 \
+		/usr/lib64/libcurl.so \
+		/lib/x86_64-linux-gnu/libcurl.so.4
+}
+
+has_curl_openssl4() {
+	local so="$1"
+	[[ -e "$so" ]] || return 1
+	so="$(readlink -f "$so")"
+	readelf -V "$so" 2>/dev/null | grep -q 'CURL_OPENSSL_4'
+}
+
+find_system_libcurl_openssl4() {
+	local p
+	while IFS= read -r p; do
+		if has_curl_openssl4 "$p"; then
+			echo "$p"
+			return 0
+		fi
+	done < <(system_libcurl_paths)
+	return 1
+}
+
+ensure_libjabra() {
+	if [[ ! -f lib/libjabra.so ]]; then
+	if [[ -f /usr/lib/jabra/libjabra.so ]]; then
+		cp -a /usr/lib/jabra/libjabra.so lib/
+		echo "Copied /usr/lib/jabra/libjabra.so -> lib/libjabra.so"
+	else
+		python3 - "$ROOT/install.sh" "$ROOT/lib/libjabra.so" <<'PY'
+import re
+import sys
+
+install_sh, out_path = sys.argv[1], sys.argv[2]
+hex_blob = None
+with open(install_sh, encoding="utf-8", errors="replace") as f:
+    for line in f:
+        if line.startswith("libjabraSo="):
+            hex_blob = line.split("=", 1)[1].strip().strip('"')
+            break
+if not hex_blob:
+    sys.exit("libjabraSo= not found in install.sh")
+data = bytes(int(h, 16) for h in re.findall(r"0x([0-9a-fA-F]{2})", hex_blob))
+with open(out_path, "wb") as out:
+    out.write(data)
+print(len(data))
+PY
+		echo "Created lib/libjabra.so ($(wc -c < lib/libjabra.so) bytes)"
+	fi
+
+	local md5
+	md5="$(md5sum lib/libjabra.so | awk '{print $1}')"
+	if [[ "$md5" != "$JABRA_MD5" ]]; then
+		echo "Checksum mismatch for lib/libjabra.so" >&2
+		rm -f lib/libjabra.so
+		exit 2
+	fi
+	fi
+
+	# Binary links against libjabra.so.1 (SONAME), same as install.sh.
+	ln -sf libjabra.so lib/libjabra.so.1
+}
+
+fetch_ubuntu_libcurl() {
+	local tmp deb
+	if ! command -v curl >/dev/null 2>&1; then
+		echo "curl required to download compatible libcurl" >&2
+		exit 1
+	fi
+	if ! command -v ar >/dev/null 2>&1 || ! command -v zstd >/dev/null 2>&1; then
+		echo "Need ar and zstd (binutils, zstd). Or: sudo dnf install binutils zstd" >&2
+		exit 1
+	fi
+
+	tmp="$(mktemp -d)"
+	deb="$tmp/libcurl.deb"
+
+	echo "Downloading Ubuntu libcurl (CURL_OPENSSL_4) ..."
+	curl -fsSL -o "$deb" "$UBUNTU_LIBCURL_DEB"
+	(
+		cd "$tmp"
+		ar x libcurl.deb
+		zstd -d -f data.tar.zst -o data.tar
+		tar xf data.tar ./usr/lib/x86_64-linux-gnu/libcurl.so.4.8.0
+	)
+	cp -a "$tmp/usr/lib/x86_64-linux-gnu/libcurl.so.4.8.0" lib/libcurl.so.4.8.0
+	ln -sf libcurl.so.4.8.0 lib/libcurl.so.4
+	rm -rf "$tmp"
+	echo "Created lib/libcurl.so.4 from Ubuntu package"
+}
+
+ensure_libcurl() {
+	if [[ -f lib/libcurl.so.4 ]] && has_curl_openssl4 lib/libcurl.so.4; then
+		return 0
+	fi
+	rm -f lib/libcurl.so.4
+
+	local sys
+	if sys="$(find_system_libcurl_openssl4)"; then
+		if [[ -L "$sys" ]]; then
+			local real
+			real="$(readlink -f "$sys")"
+			cp -a "$real" lib/libcurl.so.4.8.0
+			ln -sf libcurl.so.4.8.0 lib/libcurl.so.4
+		else
+			cp -a "$sys" lib/libcurl.so.4
+		fi
+		echo "Copied $sys -> lib/libcurl.so.4"
+		return 0
+	fi
+
+	if [[ "$(uname -m)" != "x86_64" ]]; then
+		echo "No compatible libcurl on this system and Ubuntu bundle is x86_64 only." >&2
+		echo "Build on Debian/Ubuntu or use: curl -so- …/install.sh | sudo bash" >&2
+		exit 1
+	fi
+
+	fetch_ubuntu_libcurl
+}
+
+ensure_libjabra
+ensure_libcurl
+
+echo "lib/ is ready for: go build -o jLink ."


### PR DESCRIPTION
Wires up the previously-stubbed "HeadSet Settings" menu so users can configure device-internal options (sidetone, auto-pause when laid down, boom-arm mute, mute reminder, auto-answer, etc.) without the official Jabra app.

Writes use the single-setting GUID form (Jabra_GetSetting) because submitting the full settings blob fails with ParameterFail when any unrelated entry is invalid or protected. Toggles read their valid keys from the device manifest so non-{0,1} toggles work in both directions.

Also adds setup-lib.sh to populate lib/libjabra.so (and a CURL_OPENSSL_4 libcurl on Fedora) for local builds, since lib/ is gitignored.